### PR TITLE
Fix access of undefined token in `required-v-for-key`

### DIFF
--- a/src/rules/require-v-for-key.ts
+++ b/src/rules/require-v-for-key.ts
@@ -50,7 +50,7 @@ export default {
             return;
           }
 
-          const lastTagToken: TagToken = tokens[lastTagTokenIndex!] as TagToken;
+          const lastTagToken: TagToken | undefined = tokens[lastTagTokenIndex!] as TagToken | undefined;
 
           // `template` and `slot` doesn't need a key directly but a child of them
           if (lastTagToken && (lastTagToken.val === 'template' || lastTagToken.val === 'slot')) {

--- a/src/rules/require-v-for-key.ts
+++ b/src/rules/require-v-for-key.ts
@@ -53,7 +53,7 @@ export default {
           const lastTagToken: TagToken = tokens[lastTagTokenIndex!] as TagToken;
 
           // `template` and `slot` doesn't need a key directly but a child of them
-          if (lastTagToken.val === 'template' || lastTagToken.val === 'slot') {
+          if (lastTagToken && (lastTagToken.val === 'template' || lastTagToken.val === 'slot')) {
             const childTagTokens: TagToken[] = getChildTags(lastTagToken, tokens);
             if (childTagTokens.every((tag) => tag.val === 'template' || tag.val === 'slot')) {
               return;
@@ -73,7 +73,7 @@ export default {
           }
 
           // A custom component could handle it by itself
-          if (isCustomComponent(lastTagToken, tokens)) {
+          if (lastTagToken && isCustomComponent(lastTagToken, tokens)) {
             return;
           }
 

--- a/tests/rules/require-v-for-key.test.ts
+++ b/tests/rules/require-v-for-key.test.ts
@@ -139,6 +139,56 @@ div
           endColumn: 13
         }
       ]
+    },
+    {
+      filename: 'test.vue',
+      code: `<template lang="pug">
+.component-test(v-on="$listeners")
+  .bar(
+    v-for="(value, index) in values"
+    :style="getStyle(value, index)"
+  )
+  slot
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+
+export default Vue.component({
+  data() {
+    return {
+      values: [],
+    };
+  },
+  methods: {
+    getStyle(value, index) {
+      return \`opacity: 0.3\`
+    }
+  }
+});
+</script>
+
+<style lang="scss">
+.component-test {
+  height: 22px;
+
+  .bar {
+    width: 2px;
+    height: 100%;
+    margin-right: 2px;
+  }
+}
+</style>
+`,
+      errors: [
+        {
+          message: "Elements in iteration expect to have 'v-bind:key' directives.",
+          line: 4,
+          endLine: 4,
+          column: 5,
+          endColumn: 10
+        }
+      ]
     }
   ]
 });

--- a/tests/rules/require-v-for-key.test.ts
+++ b/tests/rules/require-v-for-key.test.ts
@@ -149,37 +149,7 @@ div
     :style="getStyle(value, index)"
   )
   slot
-</template>
-
-<script lang="ts">
-import Vue from 'vue';
-
-export default Vue.component({
-  data() {
-    return {
-      values: [],
-    };
-  },
-  methods: {
-    getStyle(value, index) {
-      return \`opacity: 0.3\`
-    }
-  }
-});
-</script>
-
-<style lang="scss">
-.component-test {
-  height: 22px;
-
-  .bar {
-    width: 2px;
-    height: 100%;
-    margin-right: 2px;
-  }
-}
-</style>
-`,
+</template>`,
       errors: [
         {
           message: "Elements in iteration expect to have 'v-bind:key' directives.",


### PR DESCRIPTION
Related to #143 

Added a new test for the bug on #143. It generated the same error as expected.

The error was caused by the variable lastTagToken being undefined. I added some validations so it won't throw the undefined error. This fixed the problem and threw the expected error. But I don't know if it solves the problem. If you can give me more intel or documentation of how this works i could check if it is resolved or not.

