### PR TITLE
Identify this plugin as source of console message

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -332,7 +332,7 @@ export function tokenLength(
     return token.loc.end.column - token.loc.start.column;
   }
 
-  console.debug('Please report token:', JSON.stringify(token));
+  console.debug('[plugin:vue-pug-sfc] Please report token:', JSON.stringify(token));
   return 0;
 }
 


### PR DESCRIPTION
I got this message regarding multiline backticks but it wasn't obvious where I was to report this issue to, so this should make it easier for people.

Thanks for the great plugin